### PR TITLE
Suggestion: Ensure that the zephyr toolchain folder is read-only

### DIFF
--- a/scripts/zephyr.code-workspace
+++ b/scripts/zephyr.code-workspace
@@ -11,13 +11,15 @@
     ],
     "settings": {
         "terminal.integrated.shell.linux": "/bin/bash",
-        "workbench.colorTheme": "Visual Studio Dark - C++"
+        "workbench.colorTheme": "Visual Studio Dark - C++",
+        "files.readonlyInclude": {
+            "/opt/toolchains/zephyr/**": true
+        }
     },
     "extensions": {
         "recommendations": [
             "ms-vscode.cpptools",
             "ms-vscode.cmake-tools"
-
         ]
     }
 }


### PR DESCRIPTION
This change will block accidental changes in the `/opt/toolchains/zephyr/`.